### PR TITLE
introduce ideal_batch_size config for async function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-datafusion = "44.0.0"
+datafusion = { version = "45.0.0" }
 tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
 async-trait = "0.1.85"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/llm/async_func.rs
+++ b/src/llm/async_func.rs
@@ -54,6 +54,18 @@ impl AsyncFuncExpr {
         )
     }
 
+    pub fn ideal_batch_size(&self) -> Result<Option<usize>> {
+        if let Some(expr) = self.func.as_any().downcast_ref::<ScalarFunctionExpr>() {
+            if let Some(udf) = expr.fun().inner().as_any().downcast_ref::<AsyncScalarUDF>() {
+                return Ok(udf.ideal_batch_size());
+            }
+        }
+        not_impl_err!(
+            "Can't get ideal_batch_size from {:?}",
+            self.func
+        )
+    }
+
     /// This (async) function is called for each record batch to evaluate the LLM expressions
     ///
     /// The output is the output of evaluating the llm expression and the input record batch

--- a/src/llm/functions/mod.rs
+++ b/src/llm/functions/mod.rs
@@ -35,6 +35,12 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
     /// The return type of the function
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType>;
 
+    /// The ideal batch size for this function
+    /// If there are multiple async functions in a plan, the batch size will be the max of all of them
+    fn ideal_batch_size(&self) -> Option<usize> {
+        None
+    }
+
     /// Invoke the function asynchronously with the async arguments
     async fn invoke_async(&self, args: &RecordBatch) -> Result<ArrayRef>;
 
@@ -61,6 +67,10 @@ pub struct AsyncScalarUDF {
 impl AsyncScalarUDF {
     pub fn new(inner: Arc<dyn AsyncScalarUDFImpl>) -> Self {
         Self { inner }
+    }
+
+    pub fn ideal_batch_size(&self) -> Option<usize> {
+        self.inner.ideal_batch_size()
     }
 
     /// Turn this AsyncUDF into a ScalarUDF, suitable for

--- a/src/llm/functions/mod.rs
+++ b/src/llm/functions/mod.rs
@@ -9,7 +9,7 @@ use datafusion::common::internal_err;
 use datafusion::common::Result;
 use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+    ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature,
 };
 use std::any::Any;
 use std::fmt::Debug;
@@ -35,8 +35,7 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
     /// The return type of the function
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType>;
 
-    /// The ideal batch size for this function
-    /// If there are multiple async functions in a plan, the batch size will be the max of all of them
+    /// The ideal batch size for this function.
     fn ideal_batch_size(&self) -> Option<usize> {
         None
     }
@@ -48,7 +47,7 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
         &self,
         args: AsyncScalarFunctionArgs,
         option: &ConfigOptions,
-    ) -> Result<ColumnarValue>;
+    ) -> Result<ArrayRef>;
 }
 
 /// A scalar UDF that must be invoked using async methods
@@ -69,6 +68,7 @@ impl AsyncScalarUDF {
         Self { inner }
     }
 
+    /// The ideal batch size for this function
     pub fn ideal_batch_size(&self) -> Option<usize> {
         self.inner.ideal_batch_size()
     }
@@ -89,7 +89,7 @@ impl AsyncScalarUDF {
         &self,
         args: AsyncScalarFunctionArgs,
         option: &ConfigOptions,
-    ) -> Result<ColumnarValue> {
+    ) -> Result<ArrayRef> {
         self.inner.invoke_async_with_args(args, option).await
     }
 }

--- a/src/llm/physical_optimizer.rs
+++ b/src/llm/physical_optimizer.rs
@@ -9,7 +9,6 @@ use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
-use datafusion::error::DataFusionError;
 
 #[derive(Debug)]
 pub struct AsyncFuncRule {}
@@ -25,19 +24,12 @@ impl PhysicalOptimizerRule for AsyncFuncRule {
     /// Rewrite to
     ///   ProjectionExec(["A", "B", "__async_fn_1" + 1]) <-- note here that the async function is not evaluated and instead is a new column
     ///     AsyncFunctionNode(["A", "B", llm_func('foo', "C")])
+    ///       CoalesceBatchesExec(target_batch_size=8124)
     ///
-    /// If the async function has an ideal batch size, coalesce the batches to that size. For example, if the ideal batch size is 64:
-    /// ```
-    ///   ProjectionExec(["A", "B", "__async_fn_1" + 1])
-    ///     AsyncFunctionNode(["A", "B", llm_func('foo', "C")])
-    ///       CoalesceBatchesExec(target_batch_size=64)
-    /// ```
-    ///
-    /// If there are multiple async functions, the batch size will be the max of all of them.
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        config: &ConfigOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         // replace ProjectionExec with async exec there are any async functions
         // TODO: handle other types of ExecutionPlans (like Filter)
@@ -68,27 +60,10 @@ impl PhysicalOptimizerRule for AsyncFuncRule {
             })
             .collect::<Vec<_>>();
 
-        let max_ideal_size = async_map
-            .async_exprs
-            .iter()
-            .map(|expr| expr.ideal_batch_size())
-            .collect::<Result<Vec<_>, DataFusionError>>()?
-            .into_iter()
-            .flatten()
-            .max();
-
-        // If any of the async functions have an ideal batch size, coalesce the batches
-        let async_exec = if max_ideal_size.is_some() {
-            let new_ideal_size = max_ideal_size.unwrap();
-            let coal_batch =
-                CoalesceBatchesExec::new(Arc::clone(proj_exec.input()), new_ideal_size);
-            AsyncFuncExec::new(async_map.async_exprs, Arc::new(coal_batch))
-        } else {
-            AsyncFuncExec::new(async_map.async_exprs, Arc::clone(proj_exec.input()))
-        };
-
+        let coal_batch =
+            CoalesceBatchesExec::new(Arc::clone(proj_exec.input()), config.execution.batch_size);
+        let async_exec = AsyncFuncExec::new(async_map.async_exprs, Arc::new(coal_batch));
         let new_proj_exec = ProjectionExec::try_new(new_exprs, Arc::new(async_exec))?;
-
         Ok(Arc::new(new_proj_exec) as _)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,12 @@
 use crate::llm::functions::config::LLMConfig;
 use crate::llm::functions::llm_bool::LLMBool;
-use crate::llm::functions::{AsyncScalarUDF, AsyncScalarUDFImpl};
+use crate::llm::functions::{AsyncScalarUDF};
 use crate::llm::physical_optimizer::AsyncFuncRule;
-use datafusion::arrow::array::AsArray;
 use datafusion::common::Result;
 use datafusion::config::{ConfigOptions, Extensions};
 use datafusion::execution::{FunctionRegistry, SessionStateBuilder};
 use datafusion::functions_aggregate::min_max::max_udaf;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use serde::{Deserialize, Serialize};
-use std::any::Any;
 use std::sync::Arc;
 
 mod llm;
@@ -57,10 +54,17 @@ async fn main() -> Result<()> {
     ctx.sql("explain select llm_bool('Does {name} locates at {region}?', c.name, c.region) from country c")
         .await?.show().await?;
 
-    ctx.sql("select llm_bool('Does {name} locate at {region}?', c.name, c.region) from country c")
+    match ctx
+        .sql("select llm_bool('Does {name} locate at {region}?', c.name, c.region) from country c")
         .await?
         .show()
-        .await?;
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Error: {}", e);
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Description
Mostly, the cost of calling an external API is expensive. It's better to minimize the number to call it.
This PR introduces the `ideal_batch_size` config for the async function. The user can decide the ideal batch size of each calling.
```rust
pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
    ...

    /// The ideal batch size for this function
    /// If there are multiple async functions in a plan, the batch size will be the max of all of them
    fn ideal_batch_size(&self) -> Option<usize> {
        None
    }
```

If an async function has `idea_batch_size`, the optimizer will add `CoalesceBatchesExec` to decrease the number of batches. 
```
   ProjectionExec(["A", "B", "__async_fn_1" + 1])
     AsyncFunctionNode(["A", "B", llm_func('foo', "C")])
       CoalesceBatchesExec(target_batch_size=64)
```

