### PR TITLE
introduce the LLM function invoking the real service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ futures = { version = "0.3.31" }
 log = "0.4.22"
 env_logger = "0.11.6"
 reqwest = { version = "0.12.12", features = ["json"] }
+comfy-table = "7.1.3"
+serde_json = "1.0.135"

--- a/src/llm/exec.rs
+++ b/src/llm/exec.rs
@@ -151,8 +151,8 @@ impl ExecutionPlan for AsyncFuncExec {
                 // append the result of evaluating the async expressions to the output
                 let mut output_arrays = batch.columns().to_vec();
                 for async_expr in async_exprs_captured.iter() {
-                    let output_array = async_expr.invoke_async(&batch).await?;
-                    output_arrays.push(output_array);
+                    let output = async_expr.invoke_with_args(&batch).await?;
+                    output_arrays.push(output.to_array(batch.num_rows())?);
                 }
                 let batch = RecordBatch::try_new(schema_captured, output_arrays)?;
                 Ok(batch)

--- a/src/llm/exec.rs
+++ b/src/llm/exec.rs
@@ -145,13 +145,14 @@ impl ExecutionPlan for AsyncFuncExec {
             // stream and satisfy lifetime requirements.
             let async_exprs_captured = Arc::clone(&async_exprs_captured);
             let schema_captured = schema_captured.clone();
+            let config_option = context.session_config().options().clone();
 
             async move {
                 let batch = batch?;
                 // append the result of evaluating the async expressions to the output
                 let mut output_arrays = batch.columns().to_vec();
                 for async_expr in async_exprs_captured.iter() {
-                    let output = async_expr.invoke_with_args(&batch).await?;
+                    let output = async_expr.invoke_with_args(&batch, &config_option).await?;
                     output_arrays.push(output.to_array(batch.num_rows())?);
                 }
                 let batch = RecordBatch::try_new(schema_captured, output_arrays)?;

--- a/src/llm/functions.rs
+++ b/src/llm/functions.rs
@@ -1,9 +1,12 @@
+use crate::llm::async_func::AsyncScalarFunctionArgs;
 use async_trait::async_trait;
 use datafusion::arrow::array::{ArrayRef, RecordBatch};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::internal_err;
 use datafusion::common::Result;
-use datafusion::logical_expr::{ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+};
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -30,6 +33,8 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
 
     /// Invoke the function asynchronously with the async arguments
     async fn invoke_async(&self, args: &RecordBatch) -> Result<ArrayRef>;
+
+    async fn invoke_async_with_args(&self, args: AsyncScalarFunctionArgs) -> Result<ColumnarValue>;
 }
 
 /// A scalar UDF that must be invoked using async methods
@@ -56,9 +61,17 @@ impl AsyncScalarUDF {
         Arc::new(ScalarUDF::new_from_impl(self))
     }
 
+    /// Invoke the function asynchronously with the record batch
+    pub async fn invoke_async(&self, batch: &RecordBatch) -> Result<ArrayRef> {
+        self.inner.invoke_async(batch).await
+    }
+
     /// Invoke the function asynchronously with the async arguments
-    pub async fn invoke_async(&self, args: &RecordBatch) -> Result<ArrayRef> {
-        self.inner.invoke_async(args).await
+    pub async fn invoke_async_with_args(
+        &self,
+        args: AsyncScalarFunctionArgs,
+    ) -> Result<ColumnarValue> {
+        self.inner.invoke_async_with_args(args).await
     }
 }
 

--- a/src/llm/functions/config.rs
+++ b/src/llm/functions/config.rs
@@ -1,0 +1,19 @@
+use datafusion::common::extensions_options;
+use datafusion::config::ConfigExtension;
+
+extensions_options! {
+    /// LLM configuration options.
+    pub struct LLMConfig {
+        /// The name of the model to use.
+        pub model: String, default = "default_model".to_string()
+        /// The endpoint for the LLM chat API.
+        pub chat_endpoint: String, default = "http://localhost:8080/chat".to_string()
+        /// The API key to use for the LLM chat API.
+        /// TODO: It's better to use Option but it's not supported yet.
+        pub api_key: String, default = "".to_string()
+    }
+}
+
+impl ConfigExtension for LLMConfig {
+    const PREFIX: &'static str = "llm";
+}

--- a/src/llm/functions/llm_bool.rs
+++ b/src/llm/functions/llm_bool.rs
@@ -1,0 +1,313 @@
+use crate::llm::async_func::AsyncScalarFunctionArgs;
+use crate::llm::functions::config::LLMConfig;
+use crate::llm::functions::AsyncScalarUDFImpl;
+use async_trait::async_trait;
+use comfy_table::{Cell, Table};
+use datafusion::arrow::array::{ArrayRef, BooleanArray, RecordBatch};
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+use datafusion::common::{exec_err, internal_err, not_impl_err, plan_err, ScalarValue};
+use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{ColumnarValue, Signature, TypeSignature, Volatility};
+use log::debug;
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::collections::HashMap;
+use std::env;
+use std::sync::Arc;
+
+/// This is a simple example of a UDF that takes a string, invokes a (remote) LLM function
+/// and returns a boolean
+#[derive(Debug)]
+pub struct LLMBool {
+    signature: Signature,
+}
+
+impl LLMBool {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![TypeSignature::VariadicAny, TypeSignature::Nullary],
+                Volatility::Volatile,
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncScalarUDFImpl for LLMBool {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "llm_bool"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion::common::Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    async fn invoke_async(&self, _args: &RecordBatch) -> datafusion::common::Result<ArrayRef> {
+        not_impl_err!("This function should not be called")
+    }
+
+    async fn invoke_async_with_args(
+        &self,
+        args: AsyncScalarFunctionArgs,
+        option: &ConfigOptions,
+    ) -> datafusion::common::Result<ColumnarValue> {
+        let ColumnarValue::Scalar(question) = &args.args[0] else {
+            return plan_err!("Expected a scalar argument");
+        };
+        let question = match question {
+            ScalarValue::Utf8(Some(question)) => question,
+            _ => return plan_err!("Expected a string argument"),
+        };
+
+        let data = args.args[1..]
+            .iter()
+            .map(|arg| arg.to_array(args.number_rows))
+            .collect::<datafusion::common::Result<Vec<_>>>()?;
+        let table = pretty_format_column(
+            &data,
+            args.schema,
+            args.number_rows,
+            &FormatOptions::default(),
+        )?;
+        let prompt = format!(
+            r#"
+Given the following data:
+{}
+
+Follow the rules for the response strictly to answer questions based on the data:
+- Placeholders `{{colum name}}` are used in the question to represent the column values.
+- The output must be strictly lowercase `true` or `false`.
+- You should only say 'true' or 'false' based on the question.
+- You should strictly only return {} rows.
+
+Evaluate each row based on the following question and return only the boolean result (`true` or `false`) for each row, without any explanation:
+<question>{}</question>
+ "#,
+            table, args.number_rows, question
+        );
+
+        debug!("Generated prompt: {}", prompt);
+
+        let Some(llm_config) = option.extensions.get::<LLMConfig>() else {
+            return internal_err!("LLM configuration not found");
+        };
+        let result = ask_llm(prompt, llm_config).await?;
+        if result.len() != args.number_rows {
+            return internal_err!(
+                "Expected {} results, got {}",
+                args.number_rows,
+                result.len()
+            );
+        }
+        let array_ref = Arc::new(BooleanArray::from(result));
+        let columnar_value = ColumnarValue::Array(array_ref);
+        Ok(columnar_value)
+    }
+}
+
+pub fn pretty_format_column(
+    columns: &[ArrayRef],
+    schema: SchemaRef,
+    number_rows: usize,
+    options: &FormatOptions,
+) -> datafusion::common::Result<Table> {
+    let mut table = Table::new();
+    table.load_preset(comfy_table::presets::UTF8_FULL_CONDENSED);
+
+    if columns.is_empty() {
+        return Ok(table);
+    }
+
+    let header = schema
+        .fields()
+        .iter()
+        .map(|f| Cell::new(f.name()))
+        .collect::<Vec<_>>();
+    table.set_header(header);
+
+    let formatters = columns
+        .iter()
+        .map(|c| ArrayFormatter::try_new(c.as_ref(), options))
+        .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
+
+    for row in 0..number_rows {
+        let mut cells = Vec::new();
+        for formatter in &formatters {
+            cells.push(Cell::new(formatter.value(row)));
+        }
+        table.add_row(cells);
+    }
+    Ok(table)
+}
+
+async fn ask_llm(
+    content: impl Into<String>,
+    llm_config: &LLMConfig,
+) -> datafusion::common::Result<Vec<bool>> {
+    let messages = vec![Message {
+        role: "user".to_string(),
+        content: content.into(),
+    }];
+
+    // For the structured result, we expect an array of booleans.
+    // See ollama https://ollama.com/blog/structured-outputs
+    let mut properties = HashMap::new();
+    properties.insert(
+        "result".to_string(),
+        Property {
+            r#type: "array".to_string(),
+            item: Some(Box::new(Property {
+                r#type: "boolean".to_string(),
+                item: None,
+            })),
+        },
+    );
+
+    let body = RequestBody {
+        model: llm_config.model.clone(),
+        messages,
+        stream: false,
+        format: OutputFormat {
+            r#type: "object".to_string(),
+            properties,
+            required: vec!["result".to_string()],
+        },
+    };
+
+    debug!("ask_llm request body: {body:?}");
+
+    let response = if llm_config.api_key.is_empty() {
+        let client = reqwest::Client::new();
+        client
+            .post(&llm_config.chat_endpoint)
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+    } else {
+        let key = format!("Bearer {}", llm_config.api_key);
+        let client = reqwest::Client::new();
+        client
+            .post(&llm_config.chat_endpoint)
+            .header("Authorization", key)
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+    };
+    if response.status().is_success() {
+        let response = response.json::<Response>().await.unwrap();
+        let structured_result =
+            match serde_json::from_str::<StructuredResult>(&response.message.content) {
+                Ok(result) => result,
+                Err(e) => return exec_err!("Failed to parse response from LLM: {}", e),
+            };
+        let result = structured_result.result;
+        debug!("ask_llm response: {response:?}");
+        Ok(result)
+    } else {
+        exec_err!("Failed to send request to LLM: {}", response.status())
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct RequestBody {
+    model: String,
+    messages: Vec<Message>,
+    stream: bool,
+    format: OutputFormat,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Message {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize, Debug)]
+struct OutputFormat {
+    #[serde(rename = "type")]
+    r#type: String,
+    properties: HashMap<String, Property>,
+    required: Vec<String>,
+}
+
+#[derive(Serialize, Debug)]
+struct Property {
+    #[serde(rename = "type")]
+    r#type: String,
+    item: Option<Box<Property>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Response {
+    model: String,
+    created_at: String,
+    message: Message,
+    done_reason: String,
+    done: bool,
+    total_duration: i64,
+    load_duration: i64,
+    prompt_eval_count: i64,
+    prompt_eval_duration: i64,
+    eval_count: i32,
+    eval_duration: i64,
+}
+
+#[derive(Deserialize, Debug)]
+struct StructuredResult {
+    #[serde(default, with = "bool_from_int")]
+    result: Vec<bool>,
+}
+
+mod bool_from_int {
+    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<bool>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+        match value {
+            serde_json::Value::Array(values) => {
+                let result = values
+                    .into_iter()
+                    .map(|v| match v {
+                        serde_json::Value::Bool(b) => Ok(b),
+                        serde_json::Value::String(s) => Ok(s == "true"),
+                        serde_json::Value::Number(n) if n.is_u64() => Ok(n.as_u64().unwrap() != 0),
+                        _ => {
+                            return Err(serde::de::Error::custom(format!(
+                                "invalid type for boolean {}",
+                                v
+                            )))
+                        }
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(result)
+            }
+            _ => Err(serde::de::Error::custom(format!(
+                "expected an array but got {}",
+                value
+            ))),
+        }
+    }
+
+    pub fn serialize<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(value, serializer)
+    }
+}

--- a/src/llm/functions/mod.rs
+++ b/src/llm/functions/mod.rs
@@ -1,9 +1,13 @@
+pub mod config;
+pub mod llm_bool;
+
 use crate::llm::async_func::AsyncScalarFunctionArgs;
 use async_trait::async_trait;
 use datafusion::arrow::array::{ArrayRef, RecordBatch};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::internal_err;
 use datafusion::common::Result;
+use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
 };
@@ -34,7 +38,11 @@ pub trait AsyncScalarUDFImpl: Debug + Send + Sync {
     /// Invoke the function asynchronously with the async arguments
     async fn invoke_async(&self, args: &RecordBatch) -> Result<ArrayRef>;
 
-    async fn invoke_async_with_args(&self, args: AsyncScalarFunctionArgs) -> Result<ColumnarValue>;
+    async fn invoke_async_with_args(
+        &self,
+        args: AsyncScalarFunctionArgs,
+        option: &ConfigOptions,
+    ) -> Result<ColumnarValue>;
 }
 
 /// A scalar UDF that must be invoked using async methods
@@ -70,8 +78,9 @@ impl AsyncScalarUDF {
     pub async fn invoke_async_with_args(
         &self,
         args: AsyncScalarFunctionArgs,
+        option: &ConfigOptions,
     ) -> Result<ColumnarValue> {
-        self.inner.invoke_async_with_args(args).await
+        self.inner.invoke_async_with_args(args, option).await
     }
 }
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,4 +1,4 @@
-mod async_func;
+pub mod async_func;
 pub mod exec;
 pub mod functions;
 pub mod physical_optimizer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,15 @@
-use crate::llm::async_func::AsyncScalarFunctionArgs;
+use crate::llm::functions::config::LLMConfig;
+use crate::llm::functions::llm_bool::LLMBool;
 use crate::llm::functions::{AsyncScalarUDF, AsyncScalarUDFImpl};
 use crate::llm::physical_optimizer::AsyncFuncRule;
-use async_trait::async_trait;
-use comfy_table::{Cell, Table};
-use datafusion::arrow::array::{ArrayRef, AsArray, BooleanArray, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, Int32Type, SchemaRef};
-use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
-use datafusion::arrow::util::pretty::{pretty_format_batches, pretty_format_columns};
-use datafusion::common::{exec_err, internal_err, not_impl_err, plan_err, Result, ScalarValue};
-use datafusion::error::DataFusionError;
+use datafusion::arrow::array::AsArray;
+use datafusion::common::Result;
+use datafusion::config::{ConfigOptions, Extensions};
 use datafusion::execution::{FunctionRegistry, SessionStateBuilder};
 use datafusion::functions_aggregate::min_max::max_udaf;
-use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, Signature, TypeSignature, Volatility,
-};
-use datafusion::prelude::{col, SessionContext};
-use log::{debug, info};
+use datafusion::prelude::{SessionConfig, SessionContext};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
-use std::collections::HashMap;
-use std::env;
 use std::sync::Arc;
 
 mod llm;
@@ -28,9 +17,19 @@ mod llm;
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
+    let mut extensions = Extensions::new();
+    extensions.insert(LLMConfig::default());
+
+    let mut config = ConfigOptions::new().with_extensions(extensions);
+    config.set("llm.model", "llama3.2:3b")?;
+    config.set("llm.api_key", "")?;
+    config.set("llm.chat_endpoint", "http://localhost:11434/api/chat")?;
+
+    let session_config = SessionConfig::from(config);
 
     let mut state = SessionStateBuilder::default()
         .with_physical_optimizer_rule(Arc::new(AsyncFuncRule {}))
+        .with_config(session_config)
         .build();
 
     let llm_bool = LLMBool::new();
@@ -64,293 +63,4 @@ async fn main() -> Result<()> {
         .await?;
 
     Ok(())
-}
-
-/// This is a simple example of a UDF that takes a string, invokes a (remote) LLM function
-/// and returns a boolean
-#[derive(Debug)]
-struct LLMBool {
-    signature: Signature,
-}
-
-impl LLMBool {
-    fn new() -> Self {
-        Self {
-            signature: Signature::one_of(
-                vec![TypeSignature::VariadicAny, TypeSignature::Nullary],
-                Volatility::Volatile,
-            ),
-        }
-    }
-}
-
-#[async_trait]
-impl AsyncScalarUDFImpl for LLMBool {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &str {
-        "llm_bool"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Boolean)
-    }
-
-    async fn invoke_async(&self, _args: &RecordBatch) -> Result<ArrayRef> {
-        not_impl_err!("This function should not be called")
-    }
-
-    async fn invoke_async_with_args(&self, args: AsyncScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ColumnarValue::Scalar(question) = &args.args[0] else {
-            return plan_err!("Expected a scalar argument");
-        };
-        let question = match question {
-            ScalarValue::Utf8(Some(question)) => question,
-            _ => return plan_err!("Expected a string argument"),
-        };
-
-        let data = args.args[1..]
-            .iter()
-            .map(|arg| arg.to_array(args.number_rows))
-            .collect::<Result<Vec<_>>>()?;
-        let table = pretty_format_column(
-            &data,
-            args.schema,
-            args.number_rows,
-            &FormatOptions::default(),
-        )?;
-        let prompt = format!(
-            r#"
-Given the following data:
-{}
-
-Follow the rules for the response strictly to answer questions based on the data:
-- Placeholders `{{colum name}}` are used in the question to represent the column values.
-- The output must be strictly lowercase `true` or `false`.
-- You should only say 'true' or 'false' based on the question.
-- You should strictly only return {} rows.
-
-Evaluate each row based on the following question and return only the boolean result (`true` or `false`) for each row, without any explanation:
-<question>{}</question>
- "#,
-            table, args.number_rows, question
-        );
-
-        debug!("Generated prompt: {}", prompt);
-        let result = ask_llm(prompt).await?;
-        if result.len() != args.number_rows {
-            return internal_err!(
-                "Expected {} results, got {}",
-                args.number_rows,
-                result.len()
-            );
-        }
-        let array_ref = Arc::new(BooleanArray::from(result));
-        let columnar_value = ColumnarValue::Array(array_ref);
-        Ok(columnar_value)
-    }
-}
-
-pub fn pretty_format_column(
-    columns: &[ArrayRef],
-    schema: SchemaRef,
-    number_rows: usize,
-    options: &FormatOptions,
-) -> Result<Table> {
-    let mut table = Table::new();
-    table.load_preset(comfy_table::presets::UTF8_FULL_CONDENSED);
-
-    if columns.is_empty() {
-        return Ok(table);
-    }
-
-    let header = schema
-        .fields()
-        .iter()
-        .map(|f| Cell::new(f.name()))
-        .collect::<Vec<_>>();
-    table.set_header(header);
-
-    let formatters = columns
-        .iter()
-        .map(|c| ArrayFormatter::try_new(c.as_ref(), options))
-        .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
-
-    for row in 0..number_rows {
-        let mut cells = Vec::new();
-        for formatter in &formatters {
-            cells.push(Cell::new(formatter.value(row)));
-        }
-        table.add_row(cells);
-    }
-    Ok(table)
-}
-
-async fn ask_llm(content: impl Into<String>) -> Result<Vec<bool>> {
-    let messages = vec![Message {
-        role: "user".to_string(),
-        content: content.into(),
-    }];
-
-    // For the structured result, we expect an array of booleans.
-    // See ollama https://ollama.com/blog/structured-outputs
-    let mut properties = HashMap::new();
-    properties.insert(
-        "result".to_string(),
-        Property {
-            r#type: "array".to_string(),
-            item: Some(Box::new(Property {
-                r#type: "boolean".to_string(),
-                item: None,
-            })),
-        },
-    );
-
-    let body = RequestBody {
-        model: "llama3.2:3b".to_string(),
-        messages,
-        stream: false,
-        format: OutputFormat {
-            r#type: "object".to_string(),
-            properties,
-            required: vec!["result".to_string()],
-        },
-    };
-
-    debug!("ask_llm request body: {body:?}");
-
-    let key = match env::var("OPENAI_API_KEY") {
-        Ok(key) => Some(key),
-        Err(_) => None,
-    };
-
-    let response = if let Some(key) = key {
-        let key = format!("Bearer {}", key);
-        let client = reqwest::Client::new();
-        client
-            .post("http://localhost:11434/api/chat")
-            .header("Authorization", key)
-            .json(&body)
-            .send()
-            .await
-            .unwrap()
-    } else {
-        let client = reqwest::Client::new();
-        client
-            .post("http://localhost:11434/api/chat")
-            .json(&body)
-            .send()
-            .await
-            .unwrap()
-    };
-    if response.status().is_success() {
-        let response = response.json::<Response>().await.unwrap();
-        let structured_result =
-            match serde_json::from_str::<StructuredResult>(&response.message.content) {
-                Ok(result) => result,
-                Err(e) => return exec_err!("Failed to parse response from LLM: {}", e),
-            };
-        let result = structured_result.result;
-        debug!("ask_llm response: {response:?}");
-        Ok(result)
-    } else {
-        exec_err!("Failed to send request to LLM: {}", response.status())
-    }
-}
-
-#[derive(Serialize, Debug)]
-struct RequestBody {
-    model: String,
-    messages: Vec<Message>,
-    stream: bool,
-    format: OutputFormat,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Message {
-    role: String,
-    content: String,
-}
-
-#[derive(Serialize, Debug)]
-struct OutputFormat {
-    #[serde(rename = "type")]
-    r#type: String,
-    properties: HashMap<String, Property>,
-    required: Vec<String>,
-}
-
-#[derive(Serialize, Debug)]
-struct Property {
-    #[serde(rename = "type")]
-    r#type: String,
-    item: Option<Box<Property>>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Response {
-    model: String,
-    created_at: String,
-    message: Message,
-    done_reason: String,
-    done: bool,
-    total_duration: i64,
-    load_duration: i64,
-    prompt_eval_count: i64,
-    prompt_eval_duration: i64,
-    eval_count: i32,
-    eval_duration: i64,
-}
-
-#[derive(Deserialize, Debug)]
-struct StructuredResult {
-    #[serde(default, with = "bool_from_int")]
-    result: Vec<bool>,
-}
-
-mod bool_from_int {
-    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<bool>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
-        match value {
-            serde_json::Value::Array(values) => {
-                let result = values
-                    .into_iter()
-                    .map(|v| match v {
-                        serde_json::Value::Bool(b) => Ok(b),
-                        serde_json::Value::String(s) => Ok(s == "true"),
-                        serde_json::Value::Number(n) if n.is_u64() => Ok(n.as_u64().unwrap() != 0),
-                        _ => {
-                            return Err(serde::de::Error::custom(format!(
-                                "invalid type for boolean {}",
-                                v
-                            )))
-                        }
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(result)
-            }
-            _ => Err(serde::de::Error::custom(format!(
-                "expected an array but got {}",
-                value
-            ))),
-        }
-    }
-
-    pub fn serialize<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        Serialize::serialize(value, serializer)
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,26 @@
+use crate::llm::async_func::AsyncScalarFunctionArgs;
 use crate::llm::functions::{AsyncScalarUDF, AsyncScalarUDFImpl};
 use crate::llm::physical_optimizer::AsyncFuncRule;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, AsArray, BooleanArray, RecordBatch};
-use datafusion::arrow::datatypes::{DataType, Int32Type};
-use datafusion::common::Result;
+use comfy_table::{Cell, Table};
+use datafusion::arrow::array::{ArrayRef, AsArray, BooleanArray, RecordBatch, StringArray};
+use datafusion::arrow::datatypes::{DataType, Int32Type, SchemaRef};
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+use datafusion::arrow::util::pretty::{pretty_format_batches, pretty_format_columns};
+use datafusion::common::{exec_err, internal_err, not_impl_err, plan_err, Result, ScalarValue};
+use datafusion::error::DataFusionError;
 use datafusion::execution::{FunctionRegistry, SessionStateBuilder};
 use datafusion::functions_aggregate::min_max::max_udaf;
-use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
-use datafusion::prelude::SessionContext;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, Signature, TypeSignature, Volatility,
+};
+use datafusion::prelude::{col, SessionContext};
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
 use std::any::Any;
+use std::collections::HashMap;
+use std::env;
 use std::sync::Arc;
 
 mod llm;
@@ -26,28 +38,30 @@ async fn main() -> Result<()> {
     state.register_udf(udf.into_scalar_udf())?;
     state.register_udaf(max_udaf())?;
     let ctx = SessionContext::new_with_state(state);
-    ctx.sql("create table t1 (c1 int, c2 int, c3 int)")
+    ctx.sql("create table country (name string, region string)")
         .await?
         .show()
         .await?;
-    ctx.sql("insert into t1 values (1, 2, 3), (11, 2, 3), (1, 2, 3)")
+    ctx.sql("insert into country values ('taiwan', 'asia'), ('usa', 'north america')")
         .await?
         .show()
         .await?;
-    ctx.sql("insert into t1 values (1, 2, 3), (1, 2, 3), (21, 2, 3)")
+    ctx.sql("insert into country values  ('china', 'asia'), ('french', 'asia')")
         .await?
         .show()
         .await?;
-    ctx.sql("insert into t1 values (31, 2, 3), (1, 2, 3), (1, 2, 3)")
+    ctx.sql("insert into country values  ('french', 'europe'), ('japan', 'south america')")
         .await?
         .show()
         .await?;
 
-    ctx.sql("explain select llm_bool('If all of them are Aisa countries: {}, {}, {}', t1.c1, t1.c2, t1.c3) from t1")
+    ctx.sql("explain select llm_bool('Does {name} locates at {region}?', c.name, c.region) from country c")
         .await?.show().await?;
 
-    ctx.sql("select llm_bool('If all of them are Aisa countries: {}, {}, {}', t1.c1, t1.c2, t1.c3) from t1")
-        .await?.show().await?;
+    ctx.sql("select llm_bool('Does {name} locate at {region}?', c.name, c.region) from country c")
+        .await?
+        .show()
+        .await?;
 
     Ok(())
 }
@@ -88,69 +102,255 @@ impl AsyncScalarUDFImpl for LLMBool {
         Ok(DataType::Boolean)
     }
 
-    async fn invoke_async(&self, args: &RecordBatch) -> Result<ArrayRef> {
-        // TODO make the actual async call to open AI
-        //
-        // Note this is an async function
+    async fn invoke_async(&self, _args: &RecordBatch) -> Result<ArrayRef> {
+        not_impl_err!("This function should not be called")
+    }
 
-        // example calls the function with three integer args. We return true if
-        // the first argument is greater than 10
-        let first_arg = args.columns()[0].as_primitive::<Int32Type>();
+    async fn invoke_async_with_args(&self, args: AsyncScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ColumnarValue::Scalar(question) = &args.args[0] else {
+            return plan_err!("Expected a scalar argument");
+        };
+        let question = match question {
+            ScalarValue::Utf8(Some(question)) => question,
+            _ => return plan_err!("Expected a string argument"),
+        };
 
-        let output: BooleanArray = first_arg
+        let data = args.args[1..]
             .iter()
-            .map(|arg| arg.map(|arg| arg > 10))
-            .collect();
+            .map(|arg| arg.to_array(args.number_rows))
+            .collect::<Result<Vec<_>>>()?;
+        let table = pretty_format_column(
+            &data,
+            args.schema,
+            args.number_rows,
+            &FormatOptions::default(),
+        )?;
+        let prompt = format!(
+            r#"
+Given the following data:
+{}
 
-        Ok(Arc::new(output))
+Follow the rules for the response strictly to answer questions based on the data:
+- Placeholders `{{colum name}}` are used in the question to represent the column values.
+- The output must be strictly lowercase `true` or `false`.
+- You should only say 'true' or 'false' based on the question.
+- You should strictly only return {} rows.
+
+Evaluate each row based on the following question and return only the boolean result (`true` or `false`) for each row, without any explanation:
+<question>{}</question>
+ "#,
+            table, args.number_rows, question
+        );
+
+        debug!("Generated prompt: {}", prompt);
+        let result = ask_llm(prompt).await?;
+        if result.len() != args.number_rows {
+            return internal_err!(
+                "Expected {} results, got {}",
+                args.number_rows,
+                result.len()
+            );
+        }
+        let array_ref = Arc::new(BooleanArray::from(result));
+        let columnar_value = ColumnarValue::Array(array_ref);
+        Ok(columnar_value)
     }
 }
 
-// TODO:
-//  pretty batch and concat with promotion
-//  as the input of the LLM function
-// async fn ask_openai() -> Result<Option<String>> {
-//     let messages = vec![Message {
-//         role: "user".to_string(),
-//         content: "Say this is a test!".to_string(),
-//     }];
-//     let body = MySendBody {
-//         model: "gpt-4o-mini".to_string(),
-//         messages,
-//         temperature: 0.7,
-//     };
-//
-//     let key = match env::var("OPENAI_API_KEY") {
-//         Ok(key) => key,
-//         Err(e) => panic!("OPENAI_API_KEY is not set: {}", e),
-//     };
-//     let key = format!("Bearer {}", key);
-//     let client = reqwest::Client::new();
-//     let response = client.post("https://api.openai.com/v1/chat/completions")
-//         .header("Authorization", key)
-//         .json(&body)
-//         .send().await
-//         .map_err(|e| {
-//             internal_err!("Failed to send request to OpenAI: {}", e)
-//         })?;
-//     if response.status().is_success() {
-//         response.text()
-//     }
-//     else {
-//         internal_err!("Failed to send request to OpenAI: {}", response.status())
-//     }
-// }
-/*
-#[derive(Serialize)]
-struct MySendBody {
-    model: String,
-    messages: Vec<Message>,
-    temperature: f32,
+pub fn pretty_format_column(
+    columns: &[ArrayRef],
+    schema: SchemaRef,
+    number_rows: usize,
+    options: &FormatOptions,
+) -> Result<Table> {
+    let mut table = Table::new();
+    table.load_preset(comfy_table::presets::UTF8_FULL_CONDENSED);
+
+    if columns.is_empty() {
+        return Ok(table);
+    }
+
+    let header = schema
+        .fields()
+        .iter()
+        .map(|f| Cell::new(f.name()))
+        .collect::<Vec<_>>();
+    table.set_header(header);
+
+    let formatters = columns
+        .iter()
+        .map(|c| ArrayFormatter::try_new(c.as_ref(), options))
+        .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
+
+    for row in 0..number_rows {
+        let mut cells = Vec::new();
+        for formatter in &formatters {
+            cells.push(Cell::new(formatter.value(row)));
+        }
+        table.add_row(cells);
+    }
+    Ok(table)
 }
 
-#[derive(Serialize)]
+async fn ask_llm(content: impl Into<String>) -> Result<Vec<bool>> {
+    let messages = vec![Message {
+        role: "user".to_string(),
+        content: content.into(),
+    }];
+
+    // For the structured result, we expect an array of booleans.
+    // See ollama https://ollama.com/blog/structured-outputs
+    let mut properties = HashMap::new();
+    properties.insert(
+        "result".to_string(),
+        Property {
+            r#type: "array".to_string(),
+            item: Some(Box::new(Property {
+                r#type: "boolean".to_string(),
+                item: None,
+            })),
+        },
+    );
+
+    let body = RequestBody {
+        model: "llama3.2:3b".to_string(),
+        messages,
+        stream: false,
+        format: OutputFormat {
+            r#type: "object".to_string(),
+            properties,
+            required: vec!["result".to_string()],
+        },
+    };
+
+    debug!("ask_llm request body: {body:?}");
+
+    let key = match env::var("OPENAI_API_KEY") {
+        Ok(key) => Some(key),
+        Err(_) => None,
+    };
+
+    let response = if let Some(key) = key {
+        let key = format!("Bearer {}", key);
+        let client = reqwest::Client::new();
+        client
+            .post("http://localhost:11434/api/chat")
+            .header("Authorization", key)
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+    } else {
+        let client = reqwest::Client::new();
+        client
+            .post("http://localhost:11434/api/chat")
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+    };
+    if response.status().is_success() {
+        let response = response.json::<Response>().await.unwrap();
+        let structured_result =
+            match serde_json::from_str::<StructuredResult>(&response.message.content) {
+                Ok(result) => result,
+                Err(e) => return exec_err!("Failed to parse response from LLM: {}", e),
+            };
+        let result = structured_result.result;
+        debug!("ask_llm response: {response:?}");
+        Ok(result)
+    } else {
+        exec_err!("Failed to send request to LLM: {}", response.status())
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct RequestBody {
+    model: String,
+    messages: Vec<Message>,
+    stream: bool,
+    format: OutputFormat,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 struct Message {
     role: String,
     content: String,
 }
-*/
+
+#[derive(Serialize, Debug)]
+struct OutputFormat {
+    #[serde(rename = "type")]
+    r#type: String,
+    properties: HashMap<String, Property>,
+    required: Vec<String>,
+}
+
+#[derive(Serialize, Debug)]
+struct Property {
+    #[serde(rename = "type")]
+    r#type: String,
+    item: Option<Box<Property>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Response {
+    model: String,
+    created_at: String,
+    message: Message,
+    done_reason: String,
+    done: bool,
+    total_duration: i64,
+    load_duration: i64,
+    prompt_eval_count: i64,
+    prompt_eval_duration: i64,
+    eval_count: i32,
+    eval_duration: i64,
+}
+
+#[derive(Deserialize, Debug)]
+struct StructuredResult {
+    #[serde(default, with = "bool_from_int")]
+    result: Vec<bool>,
+}
+
+mod bool_from_int {
+    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<bool>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+        match value {
+            serde_json::Value::Array(values) => {
+                let result = values
+                    .into_iter()
+                    .map(|v| match v {
+                        serde_json::Value::Bool(b) => Ok(b),
+                        serde_json::Value::String(s) => Ok(s == "true"),
+                        serde_json::Value::Number(n) if n.is_u64() => Ok(n.as_u64().unwrap() != 0),
+                        _ => {
+                            return Err(serde::de::Error::custom(format!(
+                                "invalid type for boolean {}",
+                                v
+                            )))
+                        }
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(result)
+            }
+            _ => Err(serde::de::Error::custom(format!(
+                "expected an array but got {}",
+                value
+            ))),
+        }
+    }
+
+    pub fn serialize<S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(value, serializer)
+    }
+}


### PR DESCRIPTION
# Description
This PR implements the `llm_bool` function to invoke a real LLM service. Given the following config, you can invoke an LLM service that provides the OpenAI-compatible API server. (I use the `Ollama` to serve the model locally)
```rust
    pub struct LLMConfig {
        /// The name of the model to use.
        pub model: String, default = "default_model".to_string()
        /// The endpoint for the LLM chat API.
        pub chat_endpoint: String, default = "http://localhost:8080/chat".to_string()
        /// The API key to use for the LLM chat API.
        pub api_key: String, default = "".to_string()
    }
```

The basic usage like
```sql
> create table country (name string, region string)
> select llm_bool('Does {name} locate at {region}?', c.name, c.region) from country c
+-------------------------------------------------------------------+
| llm_bool(Utf8("Does {name} locate at {region}?"),c.name,c.region) |
+-------------------------------------------------------------------+
| true                                                              |
| false                                                             |
| false                                                             |
| true                                                              |
| false                                                             |
| true                                                              |
+-------------------------------------------------------------------+
```

# Known issues
## The LLM response isn't stable
We expect the return value of LLM to be a series boolean value but it's hard to guarantee the answer. It depends on which model we use. In the main program, I use `llama3.2:3b` to test but it usually returns some unexpected format that will lead to the query fails. Even though I provide more prompts for the return format, the answer is still unstable.
However, if I change to `ChatGPT-4o`, it can return the expected format and answer stably. 
